### PR TITLE
Add flask backend with dummy data

### DIFF
--- a/web/backend/README.md
+++ b/web/backend/README.md
@@ -1,0 +1,19 @@
+# Flask backend Gruppe 2 EiT
+
+## Installing prerequisites
+
+1. Install [virtualenv](https://pypi.org/project/virtualenv/)
+2. Initialize virtualenv with `virtualenv venv`
+3. Activate it for your current shell with `source venv/bin/activate`
+4. From the `backend` folder run `pip install -r requirements.txt` to install
+  packages to your virtualenv
+
+## Running the app
+
+* Make sure virtualenv is active (step 3 of installation)
+* Run `FLASK_APP=backend.py FLASK_ENV=development flask run
+
+## Accessing the backend
+
+* By default the backend is running on port 5000 and can be reached on
+  http://localhost:5000

--- a/web/backend/app/__init__.py
+++ b/web/backend/app/__init__.py
@@ -1,0 +1,8 @@
+"""
+__init__
+"""
+from flask import Flask
+
+app = Flask(__name__)
+
+from app import routes

--- a/web/backend/app/routes.py
+++ b/web/backend/app/routes.py
@@ -1,0 +1,38 @@
+"""
+routes.py
+"""
+import json
+from flask import request, jsonify
+from app import app
+
+
+@app.route('/')
+def hello():
+    """
+    GET /
+
+    Respond 200 OK with human-readable instructions
+    """
+    return "Hello, this is the backend, see app/routes.py for available routes"
+
+
+@app.route('/measurement', methods=['POST'])
+def add_measurement():
+    """
+    POST /measurement
+
+    TODO
+    """
+    # echo request back to client
+    return jsonify(request.form)
+
+
+@app.route('/measurements/latest-result')
+def get_most_recent_result():
+    """
+    GET /measurements/latest-result
+
+    Returns the most recent measurement (TEMPORARY DUMMY DATA)
+    """
+    with open('dummy_data.json', 'r') as dummy_data:
+        return json.load(dummy_data)['measurement_result']

--- a/web/backend/backend.py
+++ b/web/backend/backend.py
@@ -1,0 +1,5 @@
+"""
+backend.py
+Flask "main" file
+"""
+from app import app

--- a/web/backend/dummy_data.json
+++ b/web/backend/dummy_data.json
@@ -1,0 +1,25 @@
+{
+  "measurement_result": {
+    "truck_regnr": "KJ52228",
+    "trailer_regnr": "EL54224",
+    "axle_weights": [1204, 5343, 5425, 4334, 4453, 4425],
+    "axle_distances": [0, 5565, 1204, 23053, 1495, 1495],
+    "requirement_tests": [
+      {
+        "20_percent_on_steering_wheels": {
+          "pass": false,
+          "reason": "Steering wheels must have at least 20% of total weight"
+        },
+        "some_other_test": {
+          "pass": true
+        },
+        "complicated_test": {
+          "pass": true,
+          "restrictions": {
+            "bruksklasser": ["Bk10", "BkT8", "Bk8"]
+          }
+        }
+      }
+    ]
+  }
+}

--- a/web/backend/requirements.txt
+++ b/web/backend/requirements.txt
@@ -1,0 +1,6 @@
+click==7.1.1
+Flask==1.1.1
+itsdangerous==1.1.0
+Jinja2==2.11.1
+MarkupSafe==1.1.1
+Werkzeug==1.0.0


### PR DESCRIPTION
#### SUMMARY
Add flask backend with dummy data

#### NOTES
Endpoint `GET /measurements/latest-result` returns dummy data